### PR TITLE
Replace agency terminology with agriculture wording

### DIFF
--- a/Plugin/quanto-core/addons/header/header-sidebar.php
+++ b/Plugin/quanto-core/addons/header/header-sidebar.php
@@ -205,7 +205,7 @@ class Quanto_Header_Sidebar extends Widget_Base {
 			[
 				'label' 		=> __( 'Mail', 'quanto' ),
 				'type' 			=> Controls_Manager::TEXT,
-				'default'		=> __( 'hello@quanta.agency', 'quanto' ),
+				'default'		=> __( 'hello@agroland.farm', 'quanto' ),
 				'label_block'   => true,
 			]
 		);

--- a/Plugin/quanto-core/addons/widgets/award.php
+++ b/Plugin/quanto-core/addons/widgets/award.php
@@ -73,7 +73,7 @@ class Quanto_Award extends Widget_Base {
                         'award_year'  => esc_html__( 'Awwwards ─ 2023', 'quanto' ),
                     ],
                     [
-                        'award_title' => esc_html__( 'Awarded - Top Creative Agency in United State', 'quanto' ),
+                        'award_title' => esc_html__( 'Awarded - Top Agricultural Service in United States', 'quanto' ),
                         'award_year'  => esc_html__( 'Envato Elements ─ 2022', 'quanto' ),
                     ],
                     [
@@ -81,7 +81,7 @@ class Quanto_Award extends Widget_Base {
                         'award_year'  => esc_html__( 'Design Community ─ 2022', 'quanto' ),
                     ],
                     [
-                        'award_title' => esc_html__( 'Winner - Behance Portfolio Review', 'quanto' ),
+                        'award_title' => esc_html__( 'Winner - Sustainable Farming Review', 'quanto' ),
                         'award_year'  => esc_html__( 'Behance ─ 2021', 'quanto' ),
                     ],
                     [

--- a/Plugin/quanto-core/addons/widgets/counter.php
+++ b/Plugin/quanto-core/addons/widgets/counter.php
@@ -65,7 +65,7 @@ class Quanto_Counter extends Widget_Base {
 			[
 				'label' 		=> __( 'Text', 'quanto' ),
 				'type' 			=> Controls_Manager::TEXT,
-				'default'		=> __( 'Years of agency experience', 'quanto' ),
+				'default'		=> __( 'Years of farming experience', 'quanto' ),
 				'label_block'   => true,
 			]
 		);

--- a/Plugin/quanto-core/addons/widgets/hero.php
+++ b/Plugin/quanto-core/addons/widgets/hero.php
@@ -179,7 +179,7 @@ class Quanto_Hero extends Widget_Base {
 			[
 				'label' 		=> __( 'Client Title', 'quanto' ),
 				'type' 			=> Controls_Manager::TEXT,
-				'default'		=> __( 'Award winning agency', 'quanto' ),
+				'default'		=> __( 'Award-winning farm', 'quanto' ),
 				'label_block'   => true,
                 'condition' => [
 					'hero_style' => 'layout-1',
@@ -228,7 +228,7 @@ class Quanto_Hero extends Widget_Base {
 			[
 				'label' 		=> __( 'Title', 'quanto' ),
 				'type' 			=> Controls_Manager::TEXT,
-				'default'		=> __( 'Award winning agency', 'quanto' ),
+				'default'		=> __( 'Award-winning farm', 'quanto' ),
 				'label_block'   => true,
 			]
 		);

--- a/Plugin/quanto-core/addons/widgets/service.php
+++ b/Plugin/quanto-core/addons/widgets/service.php
@@ -118,7 +118,7 @@ class Quanto_Service extends \Elementor\Widget_Base {
                 'label' => esc_html__('Discription Text', 'quanto'),
                 'type' => \Elementor\Controls_Manager::TEXTAREA,
                 'label_block' => true,
-                'default' => esc_html__('Brand identity design a the have to success whether you breath onfire quanto agency. ', 'quanto'),
+                'default' => esc_html__('Innovative agricultural services that help your farm thrive.', 'quanto'),
             ]
         );
         $repeater->add_control(

--- a/Plugin/quanto-core/inc/demo-data/demo-import.php
+++ b/Plugin/quanto-core/inc/demo-data/demo-import.php
@@ -15,7 +15,7 @@ function quanto_import_files() {
 
     return array(
         array(
-            'import_file_name'             => esc_html__('Quanto Demo','quanto'),
+            'import_file_name'             => esc_html__('Agroland Demo','quanto'),
             'local_import_file'            =>  QUANTO_DEMO_DIR_PATH  . 'quanto-demo.xml',
             'local_import_widget_file'     =>  QUANTO_DEMO_DIR_PATH  . 'widgets.wie',
             'local_import_customizer_file' =>  QUANTO_DEMO_DIR_PATH  . 'customizer.dat',
@@ -42,7 +42,7 @@ function quanto_after_import_setup() {
 	);
 
 	// Assign front page and posts page (blog page).
-	$front_page_id 	= get_page_by_title( 'Digital Agency' );
+	$front_page_id 	= get_page_by_title( esc_html__( 'Farm Home', 'quanto' ) );
 	$blog_page_id  	= get_page_by_title( 'Blog Grid' );
 
 	update_option( 'show_on_front', 'page' );
@@ -83,7 +83,7 @@ add_filter( 'pt-ocdi/disable_pt_branding', '__return_true' );
 //change the location, title and other parameters of the plugin page
 function quanto_import_plugin_page_setup( $default_settings ) {
 	$default_settings['parent_slug'] = 'themes.php';
-	$default_settings['page_title']  = esc_html__( 'Quanto Demo Import' , 'quanto' );
+	$default_settings['page_title']  = esc_html__( 'Agroland Demo Import' , 'quanto' );
 	$default_settings['menu_title']  = esc_html__( 'Import Demo Data' , 'quanto' );
 	$default_settings['capability']  = 'import';
 	$default_settings['menu_slug']   = 'quanto-demo-import';

--- a/Plugin/quanto-core/inc/widgets/about-me-widget.php
+++ b/Plugin/quanto-core/inc/widgets/about-me-widget.php
@@ -21,7 +21,7 @@ class quanto_about_me_widget extends WP_Widget {
                 'quanto_about_me_widget', 
             
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: About Me', 'quanto' ),
+                esc_html__( 'Agroland :: About Me', 'quanto' ),
             
                 // Widget description
                 array( 

--- a/Plugin/quanto-core/inc/widgets/about-us-widget.php
+++ b/Plugin/quanto-core/inc/widgets/about-us-widget.php
@@ -21,7 +21,7 @@ class quanto_aboutus_widget extends WP_Widget {
                 'quanto_aboutus_widget',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: About Us Widget', 'quanto' ),
+                esc_html__( 'Agroland :: About Us Widget', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/inc/widgets/contact-info-widget.php
+++ b/Plugin/quanto-core/inc/widgets/contact-info-widget.php
@@ -18,7 +18,7 @@ class quanto_contact_info_widget extends WP_Widget {
 			// Base ID of your widget
 			'quanto_contact_info_widget',
 			// Widget name will appear in UI
-			esc_html__( 'Quanto :: Contact Info', 'quanto' ),
+			esc_html__( 'Agroland :: Contact Info', 'quanto' ),
 			// Widget description
 			array(
 				'description'	 => esc_html__( 'Add Contact Info', 'quanto' ),

--- a/Plugin/quanto-core/inc/widgets/event-widget.php
+++ b/Plugin/quanto-core/inc/widgets/event-widget.php
@@ -21,7 +21,7 @@ class quanto_event_widget extends WP_Widget {
                 'quanto_event_widget',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: Event', 'quanto' ),
+                esc_html__( 'Agroland :: Event', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/inc/widgets/footer-map.php
+++ b/Plugin/quanto-core/inc/widgets/footer-map.php
@@ -18,7 +18,7 @@ class quanto_map_widget extends WP_Widget {
 			// Base ID of your widget
 			'quanto_map_widget',
 			// Widget name will appear in UI
-			esc_html__( 'Quanto :: Map', 'quanto' ),
+			esc_html__( 'Agroland :: Map', 'quanto' ),
 			// Widget description
 			array(
 				'description'	 => esc_html__( 'Add Map', 'quanto' ),

--- a/Plugin/quanto-core/inc/widgets/gallery-widget.php
+++ b/Plugin/quanto-core/inc/widgets/gallery-widget.php
@@ -21,7 +21,7 @@ class quanto_gallery_widget extends WP_Widget {
                 'quanto_gallery_widget',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: Gallery', 'quanto' ),
+                esc_html__( 'Agroland :: Gallery', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/inc/widgets/latest-post-slider.php
+++ b/Plugin/quanto-core/inc/widgets/latest-post-slider.php
@@ -21,7 +21,7 @@ class quanto_recent_posts_widget_slider extends WP_Widget {
                 'quanto_recent_posts_widget_slider',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: Recent Posts Slider', 'quanto' ),
+                esc_html__( 'Agroland :: Recent Posts Slider', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/inc/widgets/newsletter-widget.php
+++ b/Plugin/quanto-core/inc/widgets/newsletter-widget.php
@@ -18,7 +18,7 @@ class quanto_newsletter_widget extends WP_Widget {
     		// Base ID of your widget
     		'quanto_newsletter_widget',
     		// Widget name will appear in UI
-    		esc_html__( 'Quanto :: Newsletter', 'quanto' ),
+    		esc_html__( 'Agroland :: Newsletter', 'quanto' ),
     		// Widget description
     		array(
 				'description' 	              => esc_html__( 'Add Newsletter', 'quanto' ),

--- a/Plugin/quanto-core/inc/widgets/recent-post-widget.php
+++ b/Plugin/quanto-core/inc/widgets/recent-post-widget.php
@@ -21,7 +21,7 @@ class quanto_recent_posts_widget extends WP_Widget {
                 'quanto_recent_posts_widget',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: Recent Posts', 'quanto' ),
+                esc_html__( 'Agroland :: Recent Posts', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/inc/widgets/social-widget.php
+++ b/Plugin/quanto-core/inc/widgets/social-widget.php
@@ -18,7 +18,7 @@ class quanto_social_widget extends WP_Widget {
 			// Base ID of your widget
 			'quanto_social_widget',
 			// Widget name will appear in UI
-			esc_html__( 'Quanto :: Social Icon', 'quanto' ),
+			esc_html__( 'Agroland :: Social Icon', 'quanto' ),
 			// Widget description
 			array(
 				'description'	 => esc_html__( 'Add Social Icon', 'quanto' ),

--- a/Plugin/quanto-core/inc/widgets/video-box-widget.php
+++ b/Plugin/quanto-core/inc/widgets/video-box-widget.php
@@ -21,7 +21,7 @@ class quanto_videobox_widget extends WP_Widget {
                 'quanto_videobox_widget',
 
                 // Widget name will appear in UI
-                esc_html__( 'Quanto :: Video Box', 'quanto' ),
+                esc_html__( 'Agroland :: Video Box', 'quanto' ),
 
                 // Widget description
                 array(

--- a/Plugin/quanto-core/quanto-core.php
+++ b/Plugin/quanto-core/quanto-core.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Quanto Core
- * Description: This is a helper plugin of quanto theme
+ * Plugin Name: Agroland Core
+ * Description: This is a helper plugin of Agroland theme
  * Version:     1.0.1
  * Author:      Mirror
  * License:     GPL2

--- a/languages/agroland.pot
+++ b/languages/agroland.pot
@@ -1,0 +1,2942 @@
+# Copyright (C) 2025 Mirror
+# This file is distributed under the GPL2.
+msgid ""
+msgstr ""
+"Project-Id-Version: Agroland Core 1.0.1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quanto-core\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-08-09T11:02:48+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: quanto\n"
+
+#. Plugin Name of the plugin
+#: quanto-core.php
+msgid "Agroland Core"
+msgstr ""
+
+#. Description of the plugin
+#: quanto-core.php
+msgid "This is a helper plugin of Agroland theme"
+msgstr ""
+
+#. Author of the plugin
+#: quanto-core.php
+msgid "Mirror"
+msgstr ""
+
+#. translators: 1: Plugin name 2: Elementor
+#: addons/addons.php:159
+#, php-format
+msgid "\"%1$s\" requires \"%2$s\" to be installed and activated."
+msgstr ""
+
+#: addons/addons.php:160
+#: addons/addons.php:184
+#: addons/addons.php:209
+msgid "Quanto Core"
+msgstr ""
+
+#: addons/addons.php:161
+#: addons/addons.php:185
+msgid "Elementor"
+msgstr ""
+
+#. translators: 1: Plugin name 2: Elementor 3: Required Elementor version
+#. translators: 1: Plugin name 2: PHP 3: Required PHP version
+#: addons/addons.php:183
+#: addons/addons.php:208
+#, php-format
+msgid "\"%1$s\" requires \"%2$s\" version %3$s or greater."
+msgstr ""
+
+#: addons/addons.php:210
+msgid "PHP"
+msgstr ""
+
+#: addons/addons.php:345
+msgid "Quanto"
+msgstr ""
+
+#: addons/addons.php:352
+msgid "Quanto Footer Elements"
+msgstr ""
+
+#: addons/addons.php:359
+msgid "Quanto Header Elements"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:46
+msgid "Featured Image"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:101
+#: addons/dynamic-widgets/feature-image.php:159
+#: addons/widgets/animation-image.php:46
+#: addons/widgets/blog-post.php:165
+#: addons/widgets/project-slider.php:163
+#: addons/widgets/project.php:189
+#: addons/widgets/scroll-down.php:58
+#: addons/widgets/service.php:74
+#: addons/widgets/service.php:84
+#: addons/widgets/testimonial.php:330
+msgid "Image"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:107
+#: addons/dynamic-widgets/feature-image.php:437
+#: addons/dynamic-widgets/heading.php:164
+msgid "Alignment"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:111
+#: addons/dynamic-widgets/feature-image.php:441
+#: addons/dynamic-widgets/heading.php:168
+#: addons/header/header-menu.php:69
+#: addons/header/logo.php:88
+#: addons/header/main-menu.php:94
+#: addons/widgets/service.php:175
+msgid "Left"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:115
+#: addons/dynamic-widgets/feature-image.php:445
+#: addons/dynamic-widgets/heading.php:172
+#: addons/header/header-menu.php:73
+#: addons/header/main-menu.php:98
+msgid "Center"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:119
+#: addons/dynamic-widgets/feature-image.php:449
+#: addons/dynamic-widgets/heading.php:176
+#: addons/header/header-menu.php:77
+#: addons/header/logo.php:96
+#: addons/header/main-menu.php:102
+#: addons/widgets/service.php:174
+msgid "Right"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:166
+#: addons/header/menu.php:354
+#: addons/widgets/animation-image.php:85
+#: addons/widgets/hero.php:335
+#: addons/widgets/project-slider.php:170
+#: addons/widgets/project-slider.php:376
+#: addons/widgets/testimonial.php:337
+msgid "Width"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:200
+msgid "Max Width"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:234
+#: addons/header/menu.php:376
+#: addons/widgets/animation-image.php:107
+#: addons/widgets/blog-post.php:172
+#: addons/widgets/project-slider.php:192
+#: addons/widgets/project-slider.php:398
+#: addons/widgets/project.php:196
+msgid "Height"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:264
+msgid "Object Fit"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:270
+#: addons/dynamic-widgets/feature-image.php:291
+msgid "Default"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:271
+msgid "Fill"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:272
+msgid "Cover"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:273
+msgid "Contain"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:285
+msgid "Object position"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:292
+msgid "Center Top"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:293
+msgid "Center Center"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:294
+msgid "Center Bottom"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:312
+#: addons/dynamic-widgets/heading.php:236
+#: addons/widgets/process.php:213
+msgid "Normal"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:318
+#: addons/dynamic-widgets/feature-image.php:348
+msgid "Opacity"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:342
+#: addons/widgets/process.php:257
+msgid "Hover"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:372
+msgid "Transition Duration"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:388
+msgid "Hover Animation"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:405
+#: addons/dynamic-widgets/post-navigation.php:235
+#: addons/header/menu.php:405
+#: addons/header/menu.php:552
+#: addons/header/offcanvas.php:163
+#: addons/widgets/blog-post.php:248
+#: addons/widgets/blog-post.php:482
+#: addons/widgets/button.php:205
+#: addons/widgets/career.php:388
+#: addons/widgets/hero.php:762
+#: addons/widgets/pricing.php:406
+#: addons/widgets/pricing.php:495
+#: addons/widgets/process.php:233
+#: addons/widgets/project-slider.php:438
+#: addons/widgets/testimonial.php:397
+msgid "Border Radius"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:427
+msgid "Caption"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:453
+#: addons/dynamic-widgets/heading.php:180
+msgid "Justified"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:466
+#: addons/dynamic-widgets/heading.php:209
+#: addons/header/header-sidebar.php:381
+#: addons/header/header-sidebar.php:553
+msgid "Text Color"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:478
+#: addons/header/header-sidebar.php:354
+#: addons/header/header-sidebar.php:408
+#: addons/header/header-sidebar.php:462
+#: addons/header/menu.php:294
+#: addons/header/menu.php:426
+#: addons/header/menu.php:491
+#: addons/widgets/award.php:176
+#: addons/widgets/blog-post.php:423
+#: addons/widgets/button.php:151
+#: addons/widgets/career.php:125
+#: addons/widgets/career.php:343
+#: addons/widgets/hero.php:706
+#: addons/widgets/pricing.php:372
+#: addons/widgets/pricing.php:462
+#: addons/widgets/project-slider.php:235
+#: addons/widgets/project-slider.php:344
+#: addons/widgets/project.php:239
+#: addons/widgets/scroll-down.php:203
+#: addons/widgets/testimonial.php:368
+#: addons/widgets/testimonial.php:627
+#: addons/widgets/video-box.php:111
+msgid "Background Color"
+msgstr ""
+
+#: addons/dynamic-widgets/feature-image.php:503
+#: addons/widgets/button.php:256
+#: addons/widgets/career.php:409
+#: addons/widgets/pricing.php:276
+msgid "Spacing"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:44
+msgid "Heading"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:99
+#: addons/dynamic-widgets/heading.php:116
+#: addons/dynamic-widgets/heading.php:202
+#: addons/header/header-sidebar.php:188
+#: addons/widgets/award.php:104
+#: addons/widgets/blog-post.php:300
+#: addons/widgets/career.php:159
+#: addons/widgets/faqs.php:53
+#: addons/widgets/hero.php:73
+#: addons/widgets/hero.php:229
+#: addons/widgets/hero.php:283
+#: addons/widgets/pricing.php:47
+#: addons/widgets/pricing.php:143
+#: addons/widgets/process.php:51
+#: addons/widgets/process.php:136
+#: addons/widgets/project-slider.php:259
+#: addons/widgets/project.php:263
+msgid "Title"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:121
+msgid "Enter your title"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:122
+msgid "Add Your Heading Text Here"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:131
+msgid "Link"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:145
+msgid "HTML Tag"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:193
+msgid "View"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:233
+msgid "Blend Mode"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:260
+msgid "Line Style"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:267
+msgid "Enable Line?"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:269
+#: addons/header/header-sidebar.php:140
+#: addons/header/menu.php:63
+#: addons/widgets/animation-image.php:55
+#: addons/widgets/button.php:79
+#: addons/widgets/button.php:90
+#: addons/widgets/career.php:96
+#: addons/widgets/pricing.php:80
+#: addons/widgets/pricing.php:452
+#: addons/widgets/project-slider.php:122
+#: addons/widgets/project.php:143
+#: addons/widgets/testimonial.php:88
+#: inc/builder/builder.php:80
+msgid "Yes"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:270
+#: addons/header/header-sidebar.php:141
+#: addons/header/menu.php:64
+#: addons/widgets/animation-image.php:56
+#: addons/widgets/button.php:80
+#: addons/widgets/button.php:91
+#: addons/widgets/career.php:97
+#: addons/widgets/pricing.php:81
+#: addons/widgets/pricing.php:453
+#: addons/widgets/project-slider.php:123
+#: addons/widgets/project.php:144
+#: addons/widgets/testimonial.php:89
+#: inc/builder/builder.php:81
+msgid "No"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:278
+msgid "Line Color"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:291
+msgid "Line Width"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:316
+msgid "Line height"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:341
+msgid "Shape Y Position"
+msgstr ""
+
+#: addons/dynamic-widgets/heading.php:366
+msgid "Shape X Position"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:48
+#: addons/dynamic-widgets/post-navigation.php:94
+msgid "Post Navigation"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:101
+msgid "Prev Text"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:103
+msgid "Previous Project"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:109
+msgid "Next Text"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:111
+msgid "Next Project"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:117
+msgid "Prev Icon"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:128
+msgid "Next Icon"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:143
+#: addons/header/search.php:55
+#: addons/widgets/button.php:46
+#: addons/widgets/project-slider.php:46
+#: addons/widgets/project.php:46
+#: addons/widgets/scroll-down.php:45
+msgid "Style"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:151
+msgid "Prev Next Text Typography"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:158
+msgid "Prev Next Text Color"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:168
+msgid " Margin"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:185
+#: addons/widgets/pricing.php:253
+#: addons/widgets/testimonial.php:581
+msgid "Icon Size"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:207
+#: addons/widgets/pricing.php:243
+msgid "Icon Color"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:217
+msgid "Icon Background Color"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:228
+#: addons/widgets/blog-post.php:241
+#: addons/widgets/testimonial.php:390
+msgid "Border"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:247
+msgid "Icon gap"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:277
+msgid "Project Titlet Typography"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:284
+msgid "Project Title Color"
+msgstr ""
+
+#: addons/dynamic-widgets/post-navigation.php:294
+msgid "Title Margin"
+msgstr ""
+
+#: addons/header/header-menu.php:20
+#: addons/header/header-menu.php:36
+#: addons/header/main-menu.php:20
+#: addons/header/main-menu.php:36
+msgid "Header Menu"
+msgstr ""
+
+#: addons/header/header-menu.php:44
+msgid "Mobile Logo"
+msgstr ""
+
+#: addons/header/header-menu.php:55
+#: addons/header/main-menu.php:80
+msgid "Menu Background Color"
+msgstr ""
+
+#: addons/header/header-menu.php:65
+#: addons/header/main-menu.php:90
+msgid "Menu Alignment"
+msgstr ""
+
+#: addons/header/header-sidebar.php:20
+#: addons/header/header-sidebar.php:52
+msgid "Header Sidebar"
+msgstr ""
+
+#: addons/header/header-sidebar.php:70
+#: addons/header/header-sidebar.php:340
+msgid "Left Side"
+msgstr ""
+
+#: addons/header/header-sidebar.php:77
+#: addons/header/logo.php:44
+#: addons/header/main-menu.php:43
+#: addons/header/menu.php:111
+msgid "Logo Type"
+msgstr ""
+
+#: addons/header/header-sidebar.php:81
+#: addons/header/logo.php:48
+#: addons/header/main-menu.php:47
+msgid "Dark"
+msgstr ""
+
+#: addons/header/header-sidebar.php:82
+#: addons/header/logo.php:49
+#: addons/header/main-menu.php:48
+msgid "White"
+msgstr ""
+
+#: addons/header/header-sidebar.php:83
+#: addons/header/logo.php:50
+#: addons/header/main-menu.php:49
+msgid "Custom"
+msgstr ""
+
+#: addons/header/header-sidebar.php:90
+#: addons/header/logo.php:58
+#: addons/header/main-menu.php:56
+msgid "Choose logo"
+msgstr ""
+
+#: addons/header/header-sidebar.php:103
+msgid "Rating Point"
+msgstr ""
+
+#: addons/header/header-sidebar.php:105
+msgid "4.8"
+msgstr ""
+
+#: addons/header/header-sidebar.php:112
+msgid "Rating Icon"
+msgstr ""
+
+#: addons/header/header-sidebar.php:119
+msgid "Rating Text"
+msgstr ""
+
+#: addons/header/header-sidebar.php:121
+msgid "2500+ reviews based on client feedback"
+msgstr ""
+
+#: addons/header/header-sidebar.php:131
+msgid "Sidebar Menu"
+msgstr ""
+
+#: addons/header/header-sidebar.php:138
+#: addons/header/menu.php:61
+msgid "Use Main Menu"
+msgstr ""
+
+#: addons/header/header-sidebar.php:181
+#: addons/header/header-sidebar.php:455
+msgid "Right Side"
+msgstr ""
+
+#: addons/header/header-sidebar.php:190
+msgid "Contact"
+msgstr ""
+
+#: addons/header/header-sidebar.php:197
+#: addons/header/menu.php:152
+#: addons/widgets/animation-title.php:46
+#: addons/widgets/animation-title.php:58
+#: addons/widgets/button.php:61
+#: addons/widgets/button.php:118
+#: addons/widgets/career.php:85
+#: addons/widgets/counter-two.php:73
+#: addons/widgets/counter-two.php:160
+#: addons/widgets/counter.php:66
+#: addons/widgets/counter.php:189
+#: addons/widgets/header-status.php:46
+#: addons/widgets/hero.php:117
+#: addons/widgets/hero.php:192
+#: addons/widgets/hero.php:503
+#: addons/widgets/list-icon.php:39
+#: addons/widgets/list-icon.php:62
+#: addons/widgets/list-icon.php:89
+#: addons/widgets/project.php:291
+#: addons/widgets/scroll-down.php:92
+#: addons/widgets/scroll-down.php:130
+#: addons/widgets/testimonial.php:411
+#: addons/widgets/text-slider-two.php:48
+#: addons/widgets/text-slider-two.php:68
+#: addons/widgets/text-slider.php:48
+#: addons/widgets/text-slider.php:83
+msgid "Text"
+msgstr ""
+
+#: addons/header/header-sidebar.php:199
+msgid "740 New South Head Rd, Triple Bay Swfw 3108, New York"
+msgstr ""
+
+#: addons/header/header-sidebar.php:206
+msgid "Mail"
+msgstr ""
+
+#: addons/header/header-sidebar.php:208
+msgid "hello@agroland.farm"
+msgstr ""
+
+#: addons/header/header-sidebar.php:215
+msgid "Mail URL"
+msgstr ""
+
+#: addons/header/header-sidebar.php:217
+msgid "link like this(mailto:) underline comes."
+msgstr ""
+
+#: addons/header/header-sidebar.php:223
+msgid "tel:"
+msgstr ""
+
+#: addons/header/header-sidebar.php:225
+msgid "+1 888 456 7890"
+msgstr ""
+
+#: addons/header/header-sidebar.php:232
+msgid "tel: URL"
+msgstr ""
+
+#: addons/header/header-sidebar.php:242
+msgid "Toggle"
+msgstr ""
+
+#: addons/header/header-sidebar.php:249
+#: addons/header/menu.php:218
+#: addons/header/menu.php:255
+#: addons/header/menu.php:322
+#: addons/header/menu.php:481
+#: addons/header/menu.php:573
+#: addons/header/menu.php:622
+#: addons/header/menu.php:660
+#: addons/header/menu.php:709
+#: addons/header/offcanvas.php:62
+#: addons/widgets/animation-title.php:65
+#: addons/widgets/award.php:111
+#: addons/widgets/award.php:138
+#: addons/widgets/blog-post.php:269
+#: addons/widgets/blog-post.php:307
+#: addons/widgets/blog-post.php:403
+#: addons/widgets/button.php:125
+#: addons/widgets/button.php:274
+#: addons/widgets/career.php:166
+#: addons/widgets/career.php:204
+#: addons/widgets/career.php:231
+#: addons/widgets/career.php:269
+#: addons/widgets/career.php:296
+#: addons/widgets/career.php:323
+#: addons/widgets/career.php:425
+#: addons/widgets/counter-two.php:113
+#: addons/widgets/counter-two.php:140
+#: addons/widgets/counter-two.php:167
+#: addons/widgets/counter.php:142
+#: addons/widgets/counter.php:169
+#: addons/widgets/counter.php:196
+#: addons/widgets/header-status.php:65
+#: addons/widgets/hero.php:290
+#: addons/widgets/hero.php:325
+#: addons/widgets/hero.php:392
+#: addons/widgets/hero.php:510
+#: addons/widgets/hero.php:624
+#: addons/widgets/hero.php:655
+#: addons/widgets/hero.php:686
+#: addons/widgets/hero.php:802
+#: addons/widgets/list-icon.php:96
+#: addons/widgets/pricing.php:150
+#: addons/widgets/pricing.php:188
+#: addons/widgets/pricing.php:226
+#: addons/widgets/pricing.php:313
+#: addons/widgets/pricing.php:352
+#: addons/widgets/process.php:114
+#: addons/widgets/process.php:143
+#: addons/widgets/process.php:183
+#: addons/widgets/project-slider.php:266
+#: addons/widgets/project-slider.php:293
+#: addons/widgets/project-slider.php:334
+#: addons/widgets/project.php:270
+#: addons/widgets/project.php:301
+#: addons/widgets/project.php:339
+#: addons/widgets/scroll-down.php:137
+#: addons/widgets/scroll-down.php:183
+#: addons/widgets/testimonial.php:287
+#: addons/widgets/testimonial.php:418
+#: addons/widgets/testimonial.php:464
+#: addons/widgets/testimonial.php:505
+#: addons/widgets/testimonial.php:548
+#: addons/widgets/testimonial.php:617
+#: addons/widgets/text-slider-two.php:75
+#: addons/widgets/text-slider.php:90
+#: addons/widgets/text-slider.php:128
+#: addons/widgets/video-box.php:89
+msgid "Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:260
+#: addons/header/menu.php:228
+#: addons/header/menu.php:265
+#: addons/header/offcanvas.php:72
+#: addons/widgets/blog-post.php:279
+#: addons/widgets/blog-post.php:317
+#: addons/widgets/button.php:138
+#: addons/widgets/button.php:288
+#: addons/widgets/career.php:333
+#: addons/widgets/career.php:435
+#: addons/widgets/hero.php:696
+#: addons/widgets/hero.php:812
+#: addons/widgets/list-icon.php:106
+#: addons/widgets/pricing.php:362
+#: addons/widgets/scroll-down.php:193
+#: addons/widgets/video-box.php:100
+msgid "Hover Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:364
+msgid "Rating Point Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:401
+#: addons/header/menu.php:22
+#: addons/header/menu.php:54
+#: addons/header/menu.php:211
+msgid "Menu"
+msgstr ""
+
+#: addons/header/header-sidebar.php:418
+msgid "Menu Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:435
+msgid "SubMenu Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:472
+#: addons/header/offcanvas.php:136
+msgid "Close Icon Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:482
+#: addons/header/offcanvas.php:146
+msgid "Close Icon Background Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:536
+msgid "Title Color"
+msgstr ""
+
+#: addons/header/header-sidebar.php:570
+msgid "Linked Text Color"
+msgstr ""
+
+#: addons/header/logo.php:21
+msgid "Quanto Site Logo"
+msgstr ""
+
+#: addons/header/logo.php:37
+#: addons/widgets/blog-post.php:44
+msgid "Layout"
+msgstr ""
+
+#: addons/header/logo.php:84
+msgid "Align"
+msgstr ""
+
+#: addons/header/logo.php:92
+msgid "top"
+msgstr ""
+
+#: addons/header/logo.php:110
+msgid "Image width"
+msgstr ""
+
+#: addons/header/logo.php:128
+#: addons/header/menu.php:639
+#: addons/header/menu.php:688
+#: addons/widgets/award.php:155
+#: addons/widgets/blog-post.php:227
+#: addons/widgets/blog-post.php:336
+#: addons/widgets/counter-two.php:92
+#: addons/widgets/hero.php:532
+#: addons/widgets/hero.php:560
+#: addons/widgets/hero.php:733
+#: addons/widgets/pricing.php:167
+#: addons/widgets/pricing.php:205
+#: addons/widgets/pricing.php:292
+#: addons/widgets/pricing.php:331
+#: addons/widgets/process.php:161
+#: addons/widgets/project-slider.php:224
+#: addons/widgets/project-slider.php:310
+#: addons/widgets/project.php:228
+#: addons/widgets/project.php:318
+#: addons/widgets/project.php:356
+#: addons/widgets/testimonial.php:305
+#: addons/widgets/testimonial.php:316
+#: addons/widgets/testimonial.php:438
+#: addons/widgets/testimonial.php:525
+#: addons/widgets/text-slider.php:162
+msgid "Margin"
+msgstr ""
+
+#: addons/header/menu.php:104
+msgid "Mobile Menu"
+msgstr ""
+
+#: addons/header/menu.php:115
+msgid "Dark Logo"
+msgstr ""
+
+#: addons/header/menu.php:116
+msgid "White Logo"
+msgstr ""
+
+#: addons/header/menu.php:117
+msgid "Custom Logo"
+msgstr ""
+
+#: addons/header/menu.php:124
+msgid "Logo Image"
+msgstr ""
+
+#: addons/header/menu.php:140
+#: addons/widgets/career.php:197
+msgid "Address"
+msgstr ""
+
+#: addons/header/menu.php:142
+msgid "27 Division St, New York,NY 10002, USA"
+msgstr ""
+
+#: addons/header/menu.php:154
+msgid "+1 800 123 654 987 "
+msgstr ""
+
+#: addons/header/menu.php:161
+#: addons/widgets/animation-image.php:64
+#: addons/widgets/button.php:70
+#: addons/widgets/hero.php:95
+#: addons/widgets/hero.php:204
+#: addons/widgets/pricing.php:99
+#: addons/widgets/scroll-down.php:113
+msgid "URL"
+msgstr ""
+
+#: addons/header/menu.php:168
+msgid "Linked Items"
+msgstr ""
+
+#: addons/header/menu.php:178
+msgid "Icon select"
+msgstr ""
+
+#: addons/header/menu.php:189
+#: addons/widgets/text-slider.php:65
+msgid "Icon Url"
+msgstr ""
+
+#: addons/header/menu.php:200
+msgid "Social Icon"
+msgstr ""
+
+#: addons/header/menu.php:248
+msgid "Sub Menu"
+msgstr ""
+
+#: addons/header/menu.php:283
+#: addons/header/menu.php:601
+#: addons/widgets/award.php:196
+#: addons/widgets/blog-post.php:216
+#: addons/widgets/button.php:184
+#: addons/widgets/career.php:135
+#: addons/widgets/career.php:370
+#: addons/widgets/counter.php:223
+#: addons/widgets/hero.php:266
+#: addons/widgets/hero.php:571
+#: addons/widgets/hero.php:744
+#: addons/widgets/pricing.php:506
+#: addons/widgets/process.php:244
+#: addons/widgets/project-slider.php:245
+#: addons/widgets/project-slider.php:420
+#: addons/widgets/project.php:175
+#: addons/widgets/project.php:249
+#: addons/widgets/testimonial.php:378
+msgid "Padding"
+msgstr ""
+
+#: addons/header/menu.php:305
+msgid "Submenu Shadow"
+msgstr ""
+
+#: addons/header/menu.php:315
+msgid "Hamburger"
+msgstr ""
+
+#: addons/header/menu.php:332
+#: addons/header/search.php:82
+#: addons/widgets/blog-post.php:450
+#: addons/widgets/button.php:229
+#: addons/widgets/project-slider.php:354
+#: addons/widgets/scroll-down.php:230
+#: addons/widgets/service.php:232
+#: addons/widgets/testimonial.php:475
+#: addons/widgets/testimonial.php:599
+#: addons/widgets/text-slider.php:139
+msgid "Size"
+msgstr ""
+
+#: addons/header/menu.php:419
+msgid "Mobile"
+msgstr ""
+
+#: addons/header/menu.php:436
+msgid "Logo Width"
+msgstr ""
+
+#: addons/header/menu.php:459
+msgid "Close Icon Size"
+msgstr ""
+
+#: addons/header/menu.php:501
+msgid "Close Icon Width"
+msgstr ""
+
+#: addons/header/menu.php:523
+msgid "Close Icon Height"
+msgstr ""
+
+#: addons/header/menu.php:566
+msgid "mobile Menu"
+msgstr ""
+
+#: addons/header/menu.php:584
+msgid "Active Color"
+msgstr ""
+
+#: addons/header/menu.php:615
+msgid "Mobile Address"
+msgstr ""
+
+#: addons/header/menu.php:653
+msgid "Linked Text"
+msgstr ""
+
+#: addons/header/menu.php:677
+#: addons/widgets/list-icon.php:124
+#: addons/widgets/list-icon.php:152
+#: addons/widgets/text-slider-two.php:92
+#: addons/widgets/text-slider.php:107
+msgid "Gap"
+msgstr ""
+
+#: addons/header/menu.php:702
+msgid "Mobile Social Icon"
+msgstr ""
+
+#: addons/header/offcanvas.php:20
+#: addons/header/offcanvas.php:36
+#: addons/header/offcanvas.php:55
+msgid "Offcanvas"
+msgstr ""
+
+#: addons/header/offcanvas.php:43
+msgid "Select Offcanvas"
+msgstr ""
+
+#: addons/header/offcanvas.php:82
+msgid "Offcanvas Background Color"
+msgstr ""
+
+#: addons/header/offcanvas.php:184
+msgid "Select a Title"
+msgstr ""
+
+#: addons/header/search.php:20
+msgid "Search Form"
+msgstr ""
+
+#: addons/header/search.php:36
+msgid "Header Search And Login"
+msgstr ""
+
+#: addons/header/search.php:43
+msgid "What are you looking for"
+msgstr ""
+
+#: addons/header/search.php:45
+msgid "Search Here..."
+msgstr ""
+
+#: addons/header/search.php:62
+msgid "Search Icon Color"
+msgstr ""
+
+#: addons/header/search.php:72
+msgid "Search Icon Hover Color"
+msgstr ""
+
+#: addons/widgets/animation-image.php:22
+#: addons/widgets/animation-image.php:39
+#: addons/widgets/animation-image.php:78
+msgid "Animation Image"
+msgstr ""
+
+#: addons/widgets/animation-image.php:53
+msgid "Need Link?"
+msgstr ""
+
+#: addons/widgets/animation-title.php:22
+#: addons/widgets/animation-title.php:39
+msgid "Animation Title"
+msgstr ""
+
+#: addons/widgets/animation-title.php:48
+#: addons/widgets/button.php:63
+#: addons/widgets/career.php:87
+#: addons/widgets/hero.php:194
+msgid "Get in touch"
+msgstr ""
+
+#: addons/widgets/award.php:21
+msgid "Quanto Award"
+msgstr ""
+
+#: addons/widgets/award.php:37
+#: addons/widgets/process.php:32
+#: addons/widgets/project-slider.php:217
+#: addons/widgets/project.php:221
+#: addons/widgets/video-box.php:38
+msgid "Content"
+msgstr ""
+
+#: addons/widgets/award.php:47
+msgid "Award Title"
+msgstr ""
+
+#: addons/widgets/award.php:49
+#: addons/widgets/award.php:72
+msgid "Winner - Best eCommerce Websites"
+msgstr ""
+
+#: addons/widgets/award.php:57
+msgid "Awards"
+msgstr ""
+
+#: addons/widgets/award.php:59
+#: addons/widgets/award.php:73
+msgid "Awwwards ─ 2023"
+msgstr ""
+
+#: addons/widgets/award.php:67
+msgid "Award List"
+msgstr ""
+
+#: addons/widgets/award.php:76
+msgid "Awarded - Top Agricultural Service in United States"
+msgstr ""
+
+#: addons/widgets/award.php:77
+msgid "Envato Elements ─ 2022"
+msgstr ""
+
+#: addons/widgets/award.php:80
+msgid "Mentioned - Honorable Mentioned"
+msgstr ""
+
+#: addons/widgets/award.php:81
+msgid "Design Community ─ 2022"
+msgstr ""
+
+#: addons/widgets/award.php:84
+msgid "Winner - Sustainable Farming Review"
+msgstr ""
+
+#: addons/widgets/award.php:85
+msgid "Behance ─ 2021"
+msgstr ""
+
+#: addons/widgets/award.php:88
+msgid "Winner - Featured App Design of the Week"
+msgstr ""
+
+#: addons/widgets/award.php:89
+msgid "UI/UX Global Award ─ 2019"
+msgstr ""
+
+#: addons/widgets/award.php:131
+msgid "Year"
+msgstr ""
+
+#: addons/widgets/award.php:169
+#: addons/widgets/blog-post.php:199
+#: addons/widgets/career.php:118
+#: addons/widgets/counter-two.php:85
+#: addons/widgets/counter.php:216
+#: addons/widgets/hero.php:249
+#: addons/widgets/process.php:204
+#: addons/widgets/project-slider.php:134
+#: addons/widgets/project.php:155
+#: addons/widgets/testimonial.php:358
+msgid "Box"
+msgstr ""
+
+#: addons/widgets/award.php:186
+msgid "HoverBackground Color"
+msgstr ""
+
+#: addons/widgets/award.php:214
+msgid "Hover Border Color"
+msgstr ""
+
+#: addons/widgets/blog-post.php:20
+msgid "Blog Post"
+msgstr ""
+
+#: addons/widgets/blog-post.php:37
+msgid "Blog Settings"
+msgstr ""
+
+#: addons/widgets/blog-post.php:48
+#: addons/widgets/button.php:50
+#: addons/widgets/project-slider.php:50
+#: addons/widgets/project.php:50
+#: addons/widgets/scroll-down.php:49
+#: addons/widgets/service.php:44
+msgid "Style 1"
+msgstr ""
+
+#: addons/widgets/blog-post.php:49
+#: addons/widgets/button.php:51
+#: addons/widgets/project-slider.php:51
+#: addons/widgets/project.php:51
+#: addons/widgets/scroll-down.php:50
+#: addons/widgets/service.php:45
+msgid "Style 2"
+msgstr ""
+
+#: addons/widgets/blog-post.php:54
+msgid "Columns per row"
+msgstr ""
+
+#: addons/widgets/blog-post.php:70
+msgid "Numbar Of Post"
+msgstr ""
+
+#: addons/widgets/blog-post.php:79
+#: addons/widgets/project-slider.php:67
+#: addons/widgets/project.php:88
+msgid "Post By:"
+msgstr ""
+
+#: addons/widgets/blog-post.php:84
+#: addons/widgets/project-slider.php:72
+#: addons/widgets/project.php:93
+msgid "Latest Post"
+msgstr ""
+
+#: addons/widgets/blog-post.php:85
+#: addons/widgets/project-slider.php:73
+#: addons/widgets/project.php:94
+msgid "Selected posts"
+msgstr ""
+
+#: addons/widgets/blog-post.php:92
+#: addons/widgets/project-slider.php:82
+#: addons/widgets/project.php:103
+msgid "Post In"
+msgstr ""
+
+#: addons/widgets/blog-post.php:105
+msgid "Order By"
+msgstr ""
+
+#: addons/widgets/blog-post.php:116
+#: addons/widgets/project-slider.php:106
+#: addons/widgets/project.php:127
+msgid "Order"
+msgstr ""
+
+#: addons/widgets/blog-post.php:133
+msgid "Blog Content"
+msgstr ""
+
+#: addons/widgets/blog-post.php:142
+msgid "Read More"
+msgstr ""
+
+#: addons/widgets/blog-post.php:151
+msgid "Show Pagination"
+msgstr ""
+
+#: addons/widgets/blog-post.php:153
+#: addons/widgets/faqs.php:43
+#: addons/widgets/service.php:139
+#: addons/widgets/testimonial.php:193
+#: addons/widgets/testimonial.php:207
+#: addons/widgets/testimonial.php:222
+#: addons/widgets/testimonial.php:233
+msgid "Show"
+msgstr ""
+
+#: addons/widgets/blog-post.php:154
+#: addons/widgets/faqs.php:44
+#: addons/widgets/service.php:140
+#: addons/widgets/testimonial.php:194
+#: addons/widgets/testimonial.php:208
+#: addons/widgets/testimonial.php:223
+#: addons/widgets/testimonial.php:234
+msgid "Hide"
+msgstr ""
+
+#: addons/widgets/blog-post.php:206
+msgid "Box bg Color"
+msgstr ""
+
+#: addons/widgets/blog-post.php:262
+msgid "Meta"
+msgstr ""
+
+#: addons/widgets/blog-post.php:290
+#: addons/widgets/blog-post.php:328
+#: addons/widgets/blog-post.php:383
+#: addons/widgets/testimonial.php:298
+#: addons/widgets/testimonial.php:431
+#: addons/widgets/testimonial.php:518
+#: addons/widgets/testimonial.php:561
+msgid "Typography"
+msgstr ""
+
+#: addons/widgets/blog-post.php:350
+#: addons/widgets/button.php:22
+#: addons/widgets/button.php:39
+#: addons/widgets/hero.php:676
+#: addons/widgets/pricing.php:345
+#: addons/widgets/video-box.php:81
+msgid "Button"
+msgstr ""
+
+#: addons/widgets/blog-post.php:360
+msgid "Button Color"
+msgstr ""
+
+#: addons/widgets/blog-post.php:371
+msgid "Button Color Hover"
+msgstr ""
+
+#: addons/widgets/blog-post.php:393
+msgid "Pagination"
+msgstr ""
+
+#: addons/widgets/blog-post.php:413
+msgid "Hover & Active Color"
+msgstr ""
+
+#: addons/widgets/blog-post.php:433
+#: addons/widgets/scroll-down.php:213
+#: addons/widgets/video-box.php:122
+msgid "Background Hover Color"
+msgstr ""
+
+#: addons/widgets/button.php:52
+#: addons/widgets/scroll-down.php:51
+#: addons/widgets/service.php:46
+msgid "Style 3"
+msgstr ""
+
+#: addons/widgets/button.php:53
+#: addons/widgets/service.php:47
+msgid "Style 4"
+msgstr ""
+
+#: addons/widgets/button.php:54
+#: addons/widgets/service.php:48
+msgid "Style 5"
+msgstr ""
+
+#: addons/widgets/button.php:77
+#: addons/widgets/career.php:94
+msgid "Need Icon?"
+msgstr ""
+
+#: addons/widgets/button.php:88
+msgid "Icon Left?"
+msgstr ""
+
+#: addons/widgets/button.php:164
+#: addons/widgets/career.php:353
+#: addons/widgets/hero.php:716
+#: addons/widgets/pricing.php:382
+#: addons/widgets/pricing.php:472
+msgid "Hover Background Color"
+msgstr ""
+
+#: addons/widgets/button.php:222
+#: addons/widgets/career.php:402
+#: addons/widgets/service.php:75
+#: addons/widgets/service.php:95
+#: addons/widgets/service.php:200
+#: addons/widgets/text-slider.php:57
+#: addons/widgets/text-slider.php:121
+msgid "Icon"
+msgstr ""
+
+#: addons/widgets/career.php:22
+#: addons/widgets/career.php:39
+msgid "Career"
+msgstr ""
+
+#: addons/widgets/career.php:146
+#: addons/widgets/project.php:165
+msgid "Border Color"
+msgstr ""
+
+#: addons/widgets/career.php:183
+#: addons/widgets/career.php:248
+msgid "margin"
+msgstr ""
+
+#: addons/widgets/career.php:224
+msgid "Date"
+msgstr ""
+
+#: addons/widgets/career.php:262
+msgid "Roles Text"
+msgstr ""
+
+#: addons/widgets/career.php:289
+msgid "Roles Number"
+msgstr ""
+
+#: addons/widgets/career.php:316
+#: addons/widgets/pricing.php:90
+#: addons/widgets/service.php:109
+#: addons/widgets/video-box.php:66
+#: inc/widgets/about-us-widget.php:123
+msgid "Button Text"
+msgstr ""
+
+#: addons/widgets/counter-two.php:22
+msgid "Counter Two"
+msgstr ""
+
+#: addons/widgets/counter-two.php:39
+#: addons/widgets/counter.php:22
+#: addons/widgets/counter.php:39
+msgid "Counter"
+msgstr ""
+
+#: addons/widgets/counter-two.php:46
+#: addons/widgets/counter-two.php:106
+msgid "Prefix"
+msgstr ""
+
+#: addons/widgets/counter-two.php:48
+msgid "$"
+msgstr ""
+
+#: addons/widgets/counter-two.php:55
+#: addons/widgets/counter-two.php:133
+#: addons/widgets/counter.php:48
+#: addons/widgets/counter.php:135
+#: addons/widgets/hero.php:156
+#: addons/widgets/process.php:42
+#: addons/widgets/process.php:106
+msgid "Number"
+msgstr ""
+
+#: addons/widgets/counter-two.php:57
+msgid "21"
+msgstr ""
+
+#: addons/widgets/counter-two.php:64
+#: addons/widgets/counter.php:57
+#: addons/widgets/counter.php:162
+msgid "Suffix"
+msgstr ""
+
+#: addons/widgets/counter-two.php:66
+msgid "M"
+msgstr ""
+
+#: addons/widgets/counter-two.php:75
+msgid "We assisted companies is securing over $21M in funding successfully."
+msgstr ""
+
+#: addons/widgets/counter.php:50
+msgid "17"
+msgstr ""
+
+#: addons/widgets/counter.php:59
+msgid "+"
+msgstr ""
+
+#: addons/widgets/counter.php:68
+msgid "Years of farming experience"
+msgstr ""
+
+#: addons/widgets/counter.php:75
+#: addons/widgets/text-slider-two.php:39
+#: addons/widgets/text-slider-two.php:57
+#: addons/widgets/text-slider.php:22
+#: addons/widgets/text-slider.php:39
+#: addons/widgets/text-slider.php:72
+msgid "Text Slider"
+msgstr ""
+
+#: addons/widgets/counter.php:83
+msgid "Row Gap"
+msgstr ""
+
+#: addons/widgets/counter.php:99
+msgid "Column Gap"
+msgstr ""
+
+#: addons/widgets/counter.php:115
+msgid "Columns"
+msgstr ""
+
+#: addons/widgets/counter.php:119
+msgid "1 Column"
+msgstr ""
+
+#: addons/widgets/counter.php:120
+msgid "2 Columns"
+msgstr ""
+
+#: addons/widgets/counter.php:121
+msgid "3 Columns"
+msgstr ""
+
+#: addons/widgets/counter.php:122
+msgid "4 Columns"
+msgstr ""
+
+#: addons/widgets/faqs.php:16
+#: addons/widgets/faqs.php:31
+#: addons/widgets/faqs.php:73
+msgid "FAQs"
+msgstr ""
+
+#: addons/widgets/faqs.php:41
+msgid "Open?"
+msgstr ""
+
+#: addons/widgets/faqs.php:55
+msgid "FAQ Item"
+msgstr ""
+
+#: addons/widgets/faqs.php:63
+#: addons/widgets/process.php:61
+#: addons/widgets/process.php:175
+msgid "Description"
+msgstr ""
+
+#: addons/widgets/faqs.php:65
+msgid "Default description."
+msgstr ""
+
+#: addons/widgets/faqs.php:66
+msgid "Type your description here"
+msgstr ""
+
+#: addons/widgets/header-status.php:22
+#: addons/widgets/header-status.php:39
+msgid "Header Status"
+msgstr ""
+
+#: addons/widgets/header-status.php:48
+msgid "Available for new opportunity"
+msgstr ""
+
+#: addons/widgets/header-status.php:58
+msgid "Status"
+msgstr ""
+
+#: addons/widgets/header-status.php:82
+msgid "Dot Color"
+msgstr ""
+
+#: addons/widgets/hero.php:23
+#: addons/widgets/hero.php:40
+msgid "Hero"
+msgstr ""
+
+#: addons/widgets/hero.php:47
+msgid "Hero Style"
+msgstr ""
+
+#: addons/widgets/hero.php:51
+#: addons/widgets/testimonial.php:49
+msgid "Style One"
+msgstr ""
+
+#: addons/widgets/hero.php:52
+#: addons/widgets/testimonial.php:50
+msgid "Style Two"
+msgstr ""
+
+#: addons/widgets/hero.php:53
+#: addons/widgets/testimonial.php:51
+msgid "Style Three"
+msgstr ""
+
+#: addons/widgets/hero.php:54
+msgid "Style Four"
+msgstr ""
+
+#: addons/widgets/hero.php:55
+msgid "Style Five"
+msgstr ""
+
+#: addons/widgets/hero.php:56
+msgid "Style Six"
+msgstr ""
+
+#: addons/widgets/hero.php:63
+#: addons/widgets/scroll-down.php:120
+msgid "Background Image"
+msgstr ""
+
+#: addons/widgets/hero.php:75
+msgid "Crafting your fantasies with a twist of"
+msgstr ""
+
+#: addons/widgets/hero.php:85
+msgid "Animated Image"
+msgstr ""
+
+#: addons/widgets/hero.php:105
+msgid "Title Two"
+msgstr ""
+
+#: addons/widgets/hero.php:107
+msgid "creativity"
+msgstr ""
+
+#: addons/widgets/hero.php:119
+msgid "As long as your dreams revolve around something like; being the proud owner spectacular website."
+msgstr ""
+
+#: addons/widgets/hero.php:126
+msgid "Add Image"
+msgstr ""
+
+#: addons/widgets/hero.php:136
+msgid "Client Image One"
+msgstr ""
+
+#: addons/widgets/hero.php:146
+msgid "Image Two"
+msgstr ""
+
+#: addons/widgets/hero.php:158
+msgid "2"
+msgstr ""
+
+#: addons/widgets/hero.php:168
+msgid "Counter Text"
+msgstr ""
+
+#: addons/widgets/hero.php:170
+msgid "k+ Clients"
+msgstr ""
+
+#: addons/widgets/hero.php:180
+msgid "Client Title"
+msgstr ""
+
+#: addons/widgets/hero.php:182
+#: addons/widgets/hero.php:231
+msgid "Award-winning farm"
+msgstr ""
+
+#: addons/widgets/hero.php:217
+msgid "Hero Slider"
+msgstr ""
+
+#: addons/widgets/hero.php:238
+msgid "Slider Item"
+msgstr ""
+
+#: addons/widgets/hero.php:315
+msgid "Title Shape"
+msgstr ""
+
+#: addons/widgets/hero.php:357
+msgid "height"
+msgstr ""
+
+#: addons/widgets/hero.php:382
+msgid "Short Title"
+msgstr ""
+
+#: addons/widgets/hero.php:413
+#: addons/widgets/hero.php:423
+msgid "Animated Image Size"
+msgstr ""
+
+#: addons/widgets/hero.php:448
+msgid "Animated Image Width"
+msgstr ""
+
+#: addons/widgets/hero.php:474
+msgid "Animated Image Height"
+msgstr ""
+
+#: addons/widgets/hero.php:550
+msgid "Client Part"
+msgstr ""
+
+#: addons/widgets/hero.php:589
+msgid "Client Image Size"
+msgstr ""
+
+#: addons/widgets/hero.php:614
+msgid "Number Title"
+msgstr ""
+
+#: addons/widgets/hero.php:645
+#: addons/widgets/testimonial.php:108
+msgid "Client Text"
+msgstr ""
+
+#: addons/widgets/hero.php:776
+msgid "Button Icon"
+msgstr ""
+
+#: addons/widgets/list-icon.php:22
+msgid "List Icon"
+msgstr ""
+
+#: addons/widgets/list-icon.php:46
+msgid "Enable Flex"
+msgstr ""
+
+#: addons/widgets/list-icon.php:48
+msgid "On"
+msgstr ""
+
+#: addons/widgets/list-icon.php:49
+msgid "Off"
+msgstr ""
+
+#: addons/widgets/list-icon.php:64
+#: addons/widgets/text-slider-two.php:50
+#: addons/widgets/text-slider.php:50
+msgid "Let’s work together"
+msgstr ""
+
+#: addons/widgets/list-icon.php:71
+msgid "Url"
+msgstr ""
+
+#: addons/widgets/list-icon.php:78
+msgid "Icons"
+msgstr ""
+
+#: addons/widgets/pricing.php:23
+msgid "Quanto Pricing"
+msgstr ""
+
+#: addons/widgets/pricing.php:39
+msgid "Pricing"
+msgstr ""
+
+#: addons/widgets/pricing.php:49
+msgid "Standard"
+msgstr ""
+
+#: addons/widgets/pricing.php:57
+msgid "SubTitle"
+msgstr ""
+
+#: addons/widgets/pricing.php:59
+msgid "Ideal for small businesses or startups."
+msgstr ""
+
+#: addons/widgets/pricing.php:66
+msgid "Price"
+msgstr ""
+
+#: addons/widgets/pricing.php:68
+msgid "$990"
+msgstr ""
+
+#: addons/widgets/pricing.php:78
+msgid "Button Icon?"
+msgstr ""
+
+#: addons/widgets/pricing.php:92
+msgid " Go with this plan"
+msgstr ""
+
+#: addons/widgets/pricing.php:123
+msgid "Feature List"
+msgstr ""
+
+#: addons/widgets/pricing.php:125
+msgid "Access to all basic features"
+msgstr ""
+
+#: addons/widgets/pricing.php:181
+msgid "Sub Title"
+msgstr ""
+
+#: addons/widgets/pricing.php:219
+msgid "Feature"
+msgstr ""
+
+#: addons/widgets/pricing.php:306
+msgid "Pricing Rate"
+msgstr ""
+
+#: addons/widgets/pricing.php:417
+msgid "Button Padding"
+msgstr ""
+
+#: addons/widgets/pricing.php:428
+msgid "Button Margin"
+msgstr ""
+
+#: addons/widgets/pricing.php:442
+msgid " Box"
+msgstr ""
+
+#: addons/widgets/pricing.php:450
+msgid "Overly Hover?"
+msgstr ""
+
+#: addons/widgets/pricing.php:482
+msgid "Box Hover Color"
+msgstr ""
+
+#: addons/widgets/process.php:16
+msgid "Quanto Process"
+msgstr ""
+
+#: addons/widgets/process.php:44
+#: addons/widgets/process.php:76
+msgid ".01"
+msgstr ""
+
+#: addons/widgets/process.php:53
+#: addons/widgets/process.php:77
+msgid "Send Email"
+msgstr ""
+
+#: addons/widgets/process.php:63
+#: addons/widgets/process.php:78
+#: addons/widgets/process.php:83
+#: addons/widgets/process.php:88
+#: addons/widgets/process.php:93
+msgid "Listen stories of user understand points and give a estimate about cost and time-frame."
+msgstr ""
+
+#: addons/widgets/process.php:71
+msgid "Process List"
+msgstr ""
+
+#: addons/widgets/process.php:81
+msgid ".02"
+msgstr ""
+
+#: addons/widgets/process.php:82
+msgid "Meet Online"
+msgstr ""
+
+#: addons/widgets/process.php:86
+msgid ".03"
+msgstr ""
+
+#: addons/widgets/process.php:87
+msgid "Price Estimation"
+msgstr ""
+
+#: addons/widgets/process.php:91
+msgid ".04"
+msgstr ""
+
+#: addons/widgets/process.php:92
+msgid "Work Together"
+msgstr ""
+
+#: addons/widgets/process.php:277
+msgid "Hover Text Color"
+msgstr ""
+
+#: addons/widgets/project-slider.php:22
+#: addons/widgets/project-slider.php:39
+msgid "Project Slider"
+msgstr ""
+
+#: addons/widgets/project-slider.php:58
+#: addons/widgets/project.php:79
+msgid "Numbar Of Posts"
+msgstr ""
+
+#: addons/widgets/project-slider.php:95
+#: addons/widgets/project.php:116
+msgid "Filter by Category"
+msgstr ""
+
+#: addons/widgets/project-slider.php:100
+#: addons/widgets/project.php:121
+msgid "Select a category to filter projects."
+msgstr ""
+
+#: addons/widgets/project-slider.php:120
+#: addons/widgets/project.php:141
+msgid "Show Date?"
+msgstr ""
+
+#: addons/widgets/project-slider.php:144
+msgid "Item Gap"
+msgstr ""
+
+#: addons/widgets/project-slider.php:286
+#: addons/widgets/project.php:332
+msgid "Date & Category"
+msgstr ""
+
+#: addons/widgets/project-slider.php:324
+#: addons/widgets/testimonial.php:571
+msgid "Arrow"
+msgstr ""
+
+#: addons/widgets/project-slider.php:475
+#: addons/widgets/project.php:394
+msgid "All Categories"
+msgstr ""
+
+#: addons/widgets/project-slider/layout-1.php:41
+#: addons/widgets/project-slider/layout-2.php:44
+#: addons/widgets/project/layout-1.php:42
+#: addons/widgets/project/layout-2.php:43
+msgid "project-thumb"
+msgstr ""
+
+#: addons/widgets/project.php:22
+#: addons/widgets/project.php:39
+msgid "Project"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:22
+#: addons/widgets/scroll-down.php:38
+msgid "Scroll Down"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:68
+msgid "Map Url"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:80
+msgid "Video Url"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:94
+msgid "Scroll down"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:101
+msgid "Play Text"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:103
+#: addons/widgets/video-box.php:68
+msgid "Play"
+msgstr ""
+
+#: addons/widgets/scroll-down.php:173
+msgid "Play Button"
+msgstr ""
+
+#: addons/widgets/service.php:14
+msgid "Services"
+msgstr ""
+
+#: addons/widgets/service.php:33
+msgid "Service Section"
+msgstr ""
+
+#: addons/widgets/service.php:41
+msgid "Select Style"
+msgstr ""
+
+#: addons/widgets/service.php:49
+msgid "Style 6"
+msgstr ""
+
+#: addons/widgets/service.php:60
+msgid "Select a Post"
+msgstr ""
+
+#: addons/widgets/service.php:71
+msgid "Icon Select"
+msgstr ""
+
+#: addons/widgets/service.php:112
+msgid "View details"
+msgstr ""
+
+#: addons/widgets/service.php:118
+msgid "Discription Text"
+msgstr ""
+
+#: addons/widgets/service.php:121
+msgid "Innovative agricultural services that help your farm thrive."
+msgstr ""
+
+#: addons/widgets/service.php:127
+msgid "Service Number"
+msgstr ""
+
+#: addons/widgets/service.php:130
+msgid "01"
+msgstr ""
+
+#: addons/widgets/service.php:137
+msgid "Show Service Feature"
+msgstr ""
+
+#: addons/widgets/service.php:149
+msgid "Feature  List"
+msgstr ""
+
+#: addons/widgets/service.php:161
+msgid "Item Delay"
+msgstr ""
+
+#: addons/widgets/service.php:164
+msgid "Set the delay time in seconds"
+msgstr ""
+
+#: addons/widgets/service.php:171
+msgid "Item Direction"
+msgstr ""
+
+#: addons/widgets/service.php:176
+msgid "Up"
+msgstr ""
+
+#: addons/widgets/service.php:177
+msgid "Down"
+msgstr ""
+
+#: addons/widgets/service.php:180
+msgid "Select the direction for the animation"
+msgstr ""
+
+#: addons/widgets/service.php:188
+msgid "Service Lists"
+msgstr ""
+
+#: addons/widgets/service.php:207
+msgid "Icon Gap"
+msgstr ""
+
+#: addons/widgets/testimonial.php:22
+msgid "Quanto Testimonial"
+msgstr ""
+
+#: addons/widgets/testimonial.php:38
+msgid "Testimonial Slider"
+msgstr ""
+
+#: addons/widgets/testimonial.php:45
+msgid "Testimonial Style"
+msgstr ""
+
+#: addons/widgets/testimonial.php:58
+#: addons/widgets/testimonial.php:277
+msgid "Slider Title"
+msgstr ""
+
+#: addons/widgets/testimonial.php:60
+msgid "Client testimonials"
+msgstr ""
+
+#: addons/widgets/testimonial.php:75
+msgid "Client Image"
+msgstr ""
+
+#: addons/widgets/testimonial.php:86
+msgid "Rating?"
+msgstr ""
+
+#: addons/widgets/testimonial.php:92
+msgid "Rating will be used only Style Two."
+msgstr ""
+
+#: addons/widgets/testimonial.php:98
+msgid "Ratting Icon"
+msgstr ""
+
+#: addons/widgets/testimonial.php:110
+msgid "“ Working with several word press themes and templates the last years, I only can say this is best in every level. I use it for my company and the reviews that I have already are all excellent. Not only the design but the code quality ”"
+msgstr ""
+
+#: addons/widgets/testimonial.php:116
+msgid "Client Name"
+msgstr ""
+
+#: addons/widgets/testimonial.php:118
+msgid "Alexander Cameron"
+msgstr ""
+
+#: addons/widgets/testimonial.php:124
+msgid "Client Designation"
+msgstr ""
+
+#: addons/widgets/testimonial.php:126
+msgid "Lead Developer"
+msgstr ""
+
+#: addons/widgets/testimonial.php:133
+msgid "Slides"
+msgstr ""
+
+#: addons/widgets/testimonial.php:138
+msgid "Jenny Bennett"
+msgstr ""
+
+#: addons/widgets/testimonial.php:139
+msgid "Senior Marketing Manager at Caya"
+msgstr ""
+
+#: addons/widgets/testimonial.php:142
+msgid "Nathan Hallmark"
+msgstr ""
+
+#: addons/widgets/testimonial.php:143
+msgid "Designer Team Head at Qxygen"
+msgstr ""
+
+#: addons/widgets/testimonial.php:146
+msgid "Danny Aronson"
+msgstr ""
+
+#: addons/widgets/testimonial.php:147
+msgid "Senior Brand Design at Goodnotes"
+msgstr ""
+
+#: addons/widgets/testimonial.php:158
+msgid "Slider Settings"
+msgstr ""
+
+#: addons/widgets/testimonial.php:168
+msgid "Slider Items"
+msgstr ""
+
+#: addons/widgets/testimonial.php:191
+msgid "Arrows?"
+msgstr ""
+
+#: addons/widgets/testimonial.php:205
+msgid "Dots?"
+msgstr ""
+
+#: addons/widgets/testimonial.php:220
+msgid "Drag?"
+msgstr ""
+
+#: addons/widgets/testimonial.php:231
+msgid "Auto Play?"
+msgstr ""
+
+#: addons/widgets/testimonial.php:242
+msgid "Autoplay Timeout"
+msgstr ""
+
+#: addons/widgets/testimonial.php:247
+msgid "1 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:248
+msgid "2 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:249
+msgid "3 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:250
+msgid "4 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:251
+msgid "5 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:252
+msgid "6 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:253
+msgid "7 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:254
+msgid "8 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:255
+msgid "9 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:256
+msgid "10 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:257
+msgid "11 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:258
+msgid "12 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:259
+msgid "13 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:260
+msgid "14 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:261
+msgid "15 Second"
+msgstr ""
+
+#: addons/widgets/testimonial.php:454
+msgid "Rating"
+msgstr ""
+
+#: addons/widgets/testimonial.php:498
+msgid "Name"
+msgstr ""
+
+#: addons/widgets/testimonial.php:541
+msgid "Designation"
+msgstr ""
+
+#: addons/widgets/text-slider-two.php:22
+msgid "Text Slider Two"
+msgstr ""
+
+#: addons/widgets/video-box.php:22
+msgid "Video Box"
+msgstr ""
+
+#: addons/widgets/video-box.php:45
+msgid "Select Layout"
+msgstr ""
+
+#: addons/widgets/video-box.php:48
+msgid "Layout 1"
+msgstr ""
+
+#: addons/widgets/video-box.php:49
+msgid "Layout 2"
+msgstr ""
+
+#: addons/widgets/video-box.php:57
+msgid "M4 Video URL"
+msgstr ""
+
+#: inc/builder/builder.php:36
+#: inc/builder/builder.php:45
+msgid "Header Option"
+msgstr ""
+
+#: inc/builder/builder.php:48
+#: inc/builder/builder.php:92
+msgid "Pre Built"
+msgstr ""
+
+#: inc/builder/builder.php:49
+#: inc/builder/builder.php:125
+msgid "Header Builder"
+msgstr ""
+
+#: inc/builder/builder.php:58
+msgid "Header Name"
+msgstr ""
+
+#: inc/builder/builder.php:71
+msgid "Footer Option"
+msgstr ""
+
+#: inc/builder/builder.php:78
+msgid "Enable Footer?"
+msgstr ""
+
+#: inc/builder/builder.php:89
+msgid "Footer Style"
+msgstr ""
+
+#: inc/builder/builder.php:93
+#: inc/builder/builder.php:124
+msgid "Footer Builder"
+msgstr ""
+
+#: inc/builder/builder.php:102
+msgid "Footer Name"
+msgstr ""
+
+#: inc/builder/builder.php:115
+#: inc/builder/builder.php:116
+msgid "Quanto Builder"
+msgstr ""
+
+#: inc/builder/builder.php:126
+#: inc/builder/builder.php:239
+#: inc/builder/builder.php:240
+#: inc/builder/builder.php:242
+msgid "Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:127
+msgid "OFF Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:130
+msgid "Archive Builder"
+msgstr ""
+
+#: inc/builder/builder.php:131
+msgid "Archive Settings"
+msgstr ""
+
+#: inc/builder/builder.php:137
+msgid "Welcome To Header And Footer Builder Of This Theme"
+msgstr ""
+
+#: inc/builder/builder.php:144
+#: inc/builder/builder.php:145
+#: inc/builder/builder.php:147
+msgid "Footer"
+msgstr ""
+
+#: inc/builder/builder.php:146
+msgid "Quanto Footer Builder"
+msgstr ""
+
+#: inc/builder/builder.php:148
+#: inc/builder/builder.php:180
+#: inc/builder/builder.php:213
+#: inc/builder/builder.php:243
+#: inc/builder/builder.php:275
+msgid "Add New"
+msgstr ""
+
+#: inc/builder/builder.php:149
+msgid "Add New Footer"
+msgstr ""
+
+#: inc/builder/builder.php:150
+msgid "New Footer"
+msgstr ""
+
+#: inc/builder/builder.php:151
+msgid "Edit Footer"
+msgstr ""
+
+#: inc/builder/builder.php:152
+msgid "View Footer"
+msgstr ""
+
+#: inc/builder/builder.php:153
+msgid "All Footer"
+msgstr ""
+
+#: inc/builder/builder.php:154
+msgid "Search Footer"
+msgstr ""
+
+#: inc/builder/builder.php:155
+msgid "Parent Footer:"
+msgstr ""
+
+#: inc/builder/builder.php:156
+msgid "No Footer found."
+msgstr ""
+
+#: inc/builder/builder.php:157
+msgid "No Footer found in Trash."
+msgstr ""
+
+#: inc/builder/builder.php:176
+#: inc/builder/builder.php:177
+#: inc/builder/builder.php:179
+msgid "Header"
+msgstr ""
+
+#: inc/builder/builder.php:178
+msgid "Quanto Header Builder"
+msgstr ""
+
+#: inc/builder/builder.php:181
+msgid "Add New Header"
+msgstr ""
+
+#: inc/builder/builder.php:182
+msgid "New Header"
+msgstr ""
+
+#: inc/builder/builder.php:183
+msgid "Edit Header"
+msgstr ""
+
+#: inc/builder/builder.php:184
+msgid "View Header"
+msgstr ""
+
+#: inc/builder/builder.php:185
+msgid "All Header"
+msgstr ""
+
+#: inc/builder/builder.php:186
+msgid "Search Header"
+msgstr ""
+
+#: inc/builder/builder.php:187
+msgid "Parent Header:"
+msgstr ""
+
+#: inc/builder/builder.php:188
+msgid "No Header found."
+msgstr ""
+
+#: inc/builder/builder.php:189
+msgid "No Header found in Trash."
+msgstr ""
+
+#: inc/builder/builder.php:209
+#: inc/builder/builder.php:210
+#: inc/builder/builder.php:212
+#: inc/builder/templates/archive-template.php:30
+msgid "Archive"
+msgstr ""
+
+#: inc/builder/builder.php:211
+msgid "Quanto Archive Builder"
+msgstr ""
+
+#: inc/builder/builder.php:214
+msgid "Add New Archive"
+msgstr ""
+
+#: inc/builder/builder.php:215
+msgid "New Archive"
+msgstr ""
+
+#: inc/builder/builder.php:216
+msgid "Edit Archive"
+msgstr ""
+
+#: inc/builder/builder.php:217
+msgid "View Archive"
+msgstr ""
+
+#: inc/builder/builder.php:218
+msgid "All Archives"
+msgstr ""
+
+#: inc/builder/builder.php:219
+msgid "Search Archives"
+msgstr ""
+
+#: inc/builder/builder.php:220
+msgid "Parent Archives:"
+msgstr ""
+
+#: inc/builder/builder.php:221
+msgid "No Archive found."
+msgstr ""
+
+#: inc/builder/builder.php:222
+msgid "No Archive found in Trash."
+msgstr ""
+
+#: inc/builder/builder.php:241
+msgid "Quanto Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:244
+msgid "Add New Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:245
+msgid "New Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:246
+msgid "Edit Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:247
+msgid "View Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:248
+msgid "All Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:249
+msgid "Search Tab Builder"
+msgstr ""
+
+#: inc/builder/builder.php:250
+msgid "Parent Tab Builder:"
+msgstr ""
+
+#: inc/builder/builder.php:251
+msgid "No Tab Builder found."
+msgstr ""
+
+#: inc/builder/builder.php:252
+msgid "No Tab Builder found in Trash."
+msgstr ""
+
+#: inc/builder/builder.php:271
+#: inc/builder/builder.php:272
+#: inc/builder/builder.php:274
+msgid "Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:273
+msgid "Quanto Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:276
+msgid "Add New Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:277
+msgid "New Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:278
+msgid "Edit Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:279
+msgid "View Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:280
+msgid "All Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:281
+msgid "Search Off Canvas Builder"
+msgstr ""
+
+#: inc/builder/builder.php:282
+msgid "Parent Off Canvas Builder:"
+msgstr ""
+
+#: inc/builder/builder.php:283
+msgid "No Off Canvas Builder found."
+msgstr ""
+
+#: inc/builder/builder.php:284
+msgid "No Off Canvas Builder found in Trash."
+msgstr ""
+
+#: inc/builder/builder.php:409
+msgid "Select an Archive Template"
+msgstr ""
+
+#: inc/builder/builder.php:449
+msgid "Archive Template Settings"
+msgstr ""
+
+#: inc/builder/builder.php:450
+msgid "Assign your custom-built archive templates to the corresponding archive pages."
+msgstr ""
+
+#: inc/builder/builder.php:458
+msgid "Blog / Posts Page Archive"
+msgstr ""
+
+#: inc/builder/builder.php:474
+msgid "Category Archive"
+msgstr ""
+
+#: inc/builder/builder.php:490
+msgid "Tag Archive"
+msgstr ""
+
+#: inc/builder/builder.php:506
+msgid "Author Archive"
+msgstr ""
+
+#: inc/builder/builder.php:522
+msgid "Date Archive"
+msgstr ""
+
+#: inc/builder/builder.php:538
+msgid "Save Settings"
+msgstr ""
+
+#: inc/builder/templates/archive-template.php:31
+msgid "No archive template has been assigned."
+msgstr ""
+
+#: inc/custom-post-types.php:34
+msgid "Add New Service"
+msgstr ""
+
+#: inc/custom-post-types.php:35
+msgid "New Service"
+msgstr ""
+
+#: inc/custom-post-types.php:36
+msgid "Edit Service"
+msgstr ""
+
+#: inc/custom-post-types.php:37
+msgid "View Service"
+msgstr ""
+
+#: inc/custom-post-types.php:38
+msgid "All Service"
+msgstr ""
+
+#: inc/custom-post-types.php:39
+msgid "Search Service"
+msgstr ""
+
+#: inc/custom-post-types.php:40
+msgid "Parent Service:"
+msgstr ""
+
+#: inc/custom-post-types.php:41
+msgid "No Service found."
+msgstr ""
+
+#: inc/custom-post-types.php:42
+msgid "No Service found in Trash."
+msgstr ""
+
+#: inc/custom-post-types.php:47
+#: inc/custom-post-types.php:87
+#: inc/custom-post-types.php:127
+#: inc/custom-post-types.php:201
+msgid "Description."
+msgstr ""
+
+#: inc/custom-post-types.php:74
+msgid "Add New Team"
+msgstr ""
+
+#: inc/custom-post-types.php:75
+msgid "New Team"
+msgstr ""
+
+#: inc/custom-post-types.php:76
+msgid "Edit Team"
+msgstr ""
+
+#: inc/custom-post-types.php:77
+msgid "View Team"
+msgstr ""
+
+#: inc/custom-post-types.php:78
+msgid "All Team"
+msgstr ""
+
+#: inc/custom-post-types.php:79
+msgid "Search Team"
+msgstr ""
+
+#: inc/custom-post-types.php:80
+msgid "Parent Team:"
+msgstr ""
+
+#: inc/custom-post-types.php:81
+msgid "No Team found."
+msgstr ""
+
+#: inc/custom-post-types.php:82
+msgid "No Team found in Trash."
+msgstr ""
+
+#: inc/custom-post-types.php:114
+msgid "Add New Project"
+msgstr ""
+
+#: inc/custom-post-types.php:115
+msgid "New Project"
+msgstr ""
+
+#: inc/custom-post-types.php:116
+msgid "Edit Project"
+msgstr ""
+
+#: inc/custom-post-types.php:117
+msgid "View Project"
+msgstr ""
+
+#: inc/custom-post-types.php:118
+msgid "All Projects"
+msgstr ""
+
+#: inc/custom-post-types.php:119
+msgid "Search Projects"
+msgstr ""
+
+#: inc/custom-post-types.php:120
+msgid "Parent Projects:"
+msgstr ""
+
+#: inc/custom-post-types.php:121
+msgid "No Projects found."
+msgstr ""
+
+#: inc/custom-post-types.php:122
+msgid "No Projects found in Trash."
+msgstr ""
+
+#: inc/custom-post-types.php:150
+msgid "Search Categorys"
+msgstr ""
+
+#: inc/custom-post-types.php:151
+msgid "Popular Categorys"
+msgstr ""
+
+#: inc/custom-post-types.php:152
+msgid "All Categorys"
+msgstr ""
+
+#: inc/custom-post-types.php:155
+msgid "Edit Category"
+msgstr ""
+
+#: inc/custom-post-types.php:156
+msgid "Update Category"
+msgstr ""
+
+#: inc/custom-post-types.php:157
+msgid "Add New Category"
+msgstr ""
+
+#: inc/custom-post-types.php:158
+msgid "New Category Name"
+msgstr ""
+
+#: inc/custom-post-types.php:159
+msgid "Separate Categorys with commas"
+msgstr ""
+
+#: inc/custom-post-types.php:160
+msgid "Add or remove Categorys"
+msgstr ""
+
+#: inc/custom-post-types.php:161
+msgid "Choose from the most used Categorys"
+msgstr ""
+
+#: inc/custom-post-types.php:162
+msgid "No Categorys found."
+msgstr ""
+
+#: inc/custom-post-types.php:163
+msgid "Categories"
+msgstr ""
+
+#: inc/custom-post-types.php:188
+msgid "Add New Job"
+msgstr ""
+
+#: inc/custom-post-types.php:189
+msgid "New Job"
+msgstr ""
+
+#: inc/custom-post-types.php:190
+msgid "Edit Job"
+msgstr ""
+
+#: inc/custom-post-types.php:191
+msgid "View Job"
+msgstr ""
+
+#: inc/custom-post-types.php:192
+msgid "All Job"
+msgstr ""
+
+#: inc/custom-post-types.php:193
+msgid "Search Job"
+msgstr ""
+
+#: inc/custom-post-types.php:194
+msgid "Parent Job:"
+msgstr ""
+
+#: inc/custom-post-types.php:195
+msgid "No Job found."
+msgstr ""
+
+#: inc/custom-post-types.php:196
+msgid "No Job found in Trash."
+msgstr ""
+
+#: inc/demo-data/demo-import.php:18
+msgid "Agroland Demo"
+msgstr ""
+
+#: inc/demo-data/demo-import.php:45
+msgid "Farm Home"
+msgstr ""
+
+#: inc/demo-data/demo-import.php:86
+msgid "Agroland Demo Import"
+msgstr ""
+
+#: inc/demo-data/demo-import.php:87
+msgid "Import Demo Data"
+msgstr ""
+
+#: inc/icons-manager.php:13
+msgid "Remix Icons"
+msgstr ""
+
+#: inc/modules/custom-css/custom-css.php:47
+msgid "Custom CSS "
+msgstr ""
+
+#: inc/modules/custom-css/custom-css.php:56
+msgid "Custom CSS"
+msgstr ""
+
+#: inc/modules/custom-css/custom-css.php:74
+msgid "Use \"selector\" keyword to target wrapper element."
+msgstr ""
+
+#: inc/quantoajax.php:39
+msgid "You are not allowed."
+msgstr ""
+
+#: inc/quantoajax.php:51
+msgid "Thank you, you have been added to our mailing list."
+msgstr ""
+
+#: inc/quantoajax.php:54
+msgid "This Email address is already exists."
+msgstr ""
+
+#: inc/quantoajax.php:56
+msgid "Sorry something went wrong."
+msgstr ""
+
+#: inc/quantoajax.php:59
+msgid "Apikey Or Listid Missing."
+msgstr ""
+
+#: inc/quantocore-functions.php:243
+msgid "Select a category"
+msgstr ""
+
+#: inc/quantocore-functions.php:343
+msgid "Responsive Column Order"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:24
+msgid "Agroland :: About Me"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:30
+msgid "Add About Me Widget"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:108
+#: inc/widgets/about-us-widget.php:114
+msgid "Upload Image"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:108
+#: inc/widgets/about-us-widget.php:114
+msgid "Change Image"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:111
+msgid "Author Name:"
+msgstr ""
+
+#: inc/widgets/about-me-widget.php:115
+msgid "Description:"
+msgstr ""
+
+#: inc/widgets/about-us-widget.php:24
+msgid "Agroland :: About Us Widget"
+msgstr ""
+
+#: inc/widgets/about-us-widget.php:29
+msgid "Add About Us Widget"
+msgstr ""
+
+#: inc/widgets/about-us-widget.php:118
+#: inc/widgets/contact-info-widget.php:111
+#: inc/widgets/event-widget.php:111
+#: inc/widgets/footer-map.php:63
+#: inc/widgets/gallery-widget.php:84
+#: inc/widgets/latest-post-slider.php:133
+#: inc/widgets/newsletter-widget.php:80
+#: inc/widgets/recent-post-widget.php:119
+#: inc/widgets/social-widget.php:67
+#: inc/widgets/video-box-widget.php:94
+msgid "Title:"
+msgstr ""
+
+#: inc/widgets/about-us-widget.php:127
+msgid "Button URL:"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:21
+msgid "Agroland :: Contact Info"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:24
+msgid "Add Contact Info"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:85
+msgid "Contect Us"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:119
+msgid "Address:"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:127
+msgid "Email :"
+msgstr ""
+
+#: inc/widgets/contact-info-widget.php:135
+msgid "Mobile :"
+msgstr ""
+
+#: inc/widgets/event-widget.php:24
+msgid "Agroland :: Event"
+msgstr ""
+
+#: inc/widgets/event-widget.php:30
+msgid "Add Event Widget"
+msgstr ""
+
+#: inc/widgets/event-widget.php:115
+#: inc/widgets/latest-post-slider.php:137
+#: inc/widgets/recent-post-widget.php:123
+msgid "Number of Posts to show:"
+msgstr ""
+
+#: inc/widgets/footer-map.php:21
+msgid "Agroland :: Map"
+msgstr ""
+
+#: inc/widgets/footer-map.php:24
+msgid "Add Map"
+msgstr ""
+
+#: inc/widgets/footer-map.php:55
+msgid "Get Direction"
+msgstr ""
+
+#: inc/widgets/gallery-widget.php:24
+msgid "Agroland :: Gallery"
+msgstr ""
+
+#: inc/widgets/gallery-widget.php:30
+msgid "Add Gallery Widget"
+msgstr ""
+
+#: inc/widgets/latest-post-slider.php:24
+msgid "Agroland :: Recent Posts Slider"
+msgstr ""
+
+#: inc/widgets/latest-post-slider.php:30
+#: inc/widgets/recent-post-widget.php:30
+msgid "Add Recent Posts Widget"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:21
+msgid "Agroland :: Newsletter"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:24
+msgid "Add Newsletter"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:45
+msgid "Sign Up Now &amp; Get 10% Off."
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:52
+msgid "Subscribe"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:65
+msgid "Subscribe Us"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:72
+msgid "Your Email Address"
+msgstr ""
+
+#: inc/widgets/newsletter-widget.php:88
+msgid "Placeholder:"
+msgstr ""
+
+#: inc/widgets/recent-post-widget.php:24
+msgid "Agroland :: Recent Posts"
+msgstr ""
+
+#: inc/widgets/social-widget.php:21
+msgid "Agroland :: Social Icon"
+msgstr ""
+
+#: inc/widgets/social-widget.php:24
+msgid "Add Social Icon"
+msgstr ""
+
+#: inc/widgets/social-widget.php:57
+msgid "Have Inquiry? Just Call"
+msgstr ""
+
+#: inc/widgets/video-box-widget.php:24
+msgid "Agroland :: Video Box"
+msgstr ""
+
+#: inc/widgets/video-box-widget.php:30
+msgid "Add Video Widget"
+msgstr ""

--- a/quanto-child/style.css
+++ b/quanto-child/style.css
@@ -1,16 +1,16 @@
 /*
-Theme Name: Quanto Child
-Theme URI: https://wp.framerpeak.com/quanto/
+Theme Name: Agroland Child
+Theme URI: https://wp.framerpeak.com/agroland/
 Author: Mirrortheme
 Author URI: https://themeforest.net/user/mirrortheme
 Template: quanto
 Tested up to: 5.8
 Requires PHP: 7.4
-Description: Quanto Child Theme - A child theme for Quanto, the Creative Agency & Portfolio WordPress Theme.
+Description: Agroland Child Theme - A child theme for Agroland, the Agriculture & Farming WordPress Theme.
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Text Domain: quanto-child
+Text Domain: agroland-child
 Copyright (C) 2025 Mirrortheme
 */
 

--- a/quanto/style.css
+++ b/quanto/style.css
@@ -1,9 +1,9 @@
 /*
-Theme Name: Quanto
-Theme URI:  https://wp.framerpeak.com/quanto/
+Theme Name: Agroland
+Theme URI:  https://wp.framerpeak.com/agroland/
 Author: Mirrortheme
 Author URI: https://themeforest.net/user/mirrortheme
-Description: Quanto - Creative Agency & Portfolio WordPress Theme
+Description: Agroland - Agriculture & Farming WordPress Theme
 Version: 1.0.1
 Tested up to: 5.8
 Requires at least: 5.6


### PR DESCRIPTION
## Summary
- Replace agency-centric strings with agriculture-focused terms and wrap in i18n functions
- Rename plugin and widget labels from Quanto to Agroland
- Add generated translation template at `languages/agroland.pot`

## Testing
- `php -l Plugin/quanto-core/addons/header/header-sidebar.php`
- `php -l Plugin/quanto-core/addons/widgets/award.php`
- `php -l Plugin/quanto-core/addons/widgets/counter.php`
- `php -l Plugin/quanto-core/addons/widgets/hero.php`
- `php -l Plugin/quanto-core/addons/widgets/service.php`
- `php -l Plugin/quanto-core/inc/demo-data/demo-import.php`
- `php -l Plugin/quanto-core/inc/widgets/about-me-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/about-us-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/contact-info-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/event-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/footer-map.php`
- `php -l Plugin/quanto-core/inc/widgets/gallery-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/latest-post-slider.php`
- `php -l Plugin/quanto-core/inc/widgets/newsletter-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/recent-post-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/social-widget.php`
- `php -l Plugin/quanto-core/inc/widgets/video-box-widget.php`
- `php -l Plugin/quanto-core/quanto-core.php`
- `wp i18n make-pot Plugin/quanto-core languages/agroland.pot --allow-root --exclude="languages"`


------
https://chatgpt.com/codex/tasks/task_e_6897284a48a883288645b6d1144ac261