### PR TITLE
Use agroland text domain for plugin localization

### DIFF
--- a/Plugin/quanto-core/quanto-core.php
+++ b/Plugin/quanto-core/quanto-core.php
@@ -7,7 +7,7 @@
  * License:     GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Domain Path: /languages
- * Text Domain: quanto
+ * Text Domain: agroland
  */
  // Blocking direct access
 if( ! defined( 'ABSPATH' ) ) {
@@ -32,7 +32,7 @@ define( 'QUANTO_CORE_PLUGIN_TEMP', plugin_dir_path( __FILE__ ) .'quanto-template
 // load textdomain
 
 add_action('init', function () {
-    load_plugin_textdomain('quanto', false, dirname(plugin_basename(__FILE__)) . '/languages');
+    load_plugin_textdomain('agroland', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
 
 //include file.


### PR DESCRIPTION
## Summary
- replace plugin text domain with `agroland`
- load translation files using the `agroland` text domain

## Testing
- `php -l Plugin/quanto-core/quanto-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68972be6738c8328923bf7799307c005